### PR TITLE
Prevent wrapping with Left/Right press (Fixes issue #9)

### DIFF
--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -42,6 +42,7 @@
 #define ENTRIES_START_ROW 1
 #define OPTIONS_ENTRIES_START_ROW 2
 #define ENTRY_PAGE_LENGTH 10
+bool bigJump = false;
 
 using namespace std;
 
@@ -447,13 +448,16 @@ string browseForFile (void) {
 			return "null";
 		}
 
-		if (pressed & KEY_UP) 		fileOffset -= 1;
-		if (pressed & KEY_DOWN) 	fileOffset += 1;
-		if (pressed & KEY_LEFT) 	fileOffset -= ENTRY_PAGE_LENGTH;
-		if (pressed & KEY_RIGHT)	fileOffset += ENTRY_PAGE_LENGTH;
+		if (pressed & KEY_UP) {		fileOffset -= 1; bigJump = false;  }
+		if (pressed & KEY_DOWN) {	fileOffset += 1; bigJump = false; }
+		if (pressed & KEY_LEFT) {	fileOffset -= ENTRY_PAGE_LENGTH; bigJump = true; }
+		if (pressed & KEY_RIGHT) {	fileOffset += ENTRY_PAGE_LENGTH; bigJump = true; }
 		
-		if (fileOffset < 0) 	fileOffset = dirContents.size() - 1;		// Wrap around to bottom of list
-		if (fileOffset > ((int)dirContents.size() - 1))		fileOffset = 0;		// Wrap around to top of list
+		if (fileOffset < 0 & bigJump == false)	fileOffset = dirContents.size() - 1;	// Wrap around to bottom of list (UP press)
+		else if (fileOffset < 0 & bigJump == true)	fileOffset = 0;		// Move to bottom of list (RIGHT press)
+		if (fileOffset > ((int)dirContents.size() - 1) & bigJump == false)	fileOffset = 0;		// Wrap around to top of list (DOWN press)
+		else if (fileOffset > ((int)dirContents.size() - 1) & bigJump == true)	fileOffset = dirContents.size() - 1;	// Move to top of list (LEFT press)
+
 
 		// Scroll screen if needed
 		if (fileOffset < screenOffset) 	{


### PR DESCRIPTION
This prevents the file selector from wrapping with Left/Right (Still wraps with Up/Down)

*Note:* I'm very new to C++, so this might not be very good coding, but if it's decent this should fix issue #9 

I tested it and it works, however in order for me to be able to build gm9i I have to remove all references to `nds-exception-stub`, so I can't 100% confirm it works when built properly, but it seems like it should to me (I'm not really sure why, but it works without nds-exception-stub, but if it exists it fails to build)