### PR TITLE
Fix deleting file when copying to same dir and add recursive copying

### DIFF
--- a/arm9/include/bmp.h
+++ b/arm9/include/bmp.h
@@ -1,0 +1,23 @@
+#ifndef _bmp_h_
+#define _bmp_h_
+
+typedef struct {
+	u16 type;						/* Magic identifier            */
+	u32 size;                       /* File size in bytes          */
+	u16 reserved1, reserved2;
+	u32 offset;                     /* Offset to image data, bytes */
+} PACKED HEADER;
+
+typedef struct {
+	u32 size;						/* Header size in bytes      */
+	u32 width,height;				/* Width and height of image */
+	u16 planes;						/* Number of colour planes   */
+	u16 bits;						/* Bits per pixel            */
+	u32 compression;				/* Compression type          */
+	u32 imagesize;					/* Image size in bytes       */
+	u32 xresolution,yresolution;	/* Pixels per meter          */
+	u32 ncolours;					/* Number of colours         */
+	u32 importantcolours;			/* Important colours         */
+} PACKED INFOHEADER;
+
+#endif //_bmp_h_

--- a/arm9/include/screenshot.h
+++ b/arm9/include/screenshot.h
@@ -1,0 +1,2 @@
+void screenshot(const char* filename);
+void screenshotbmp(const char* filename);

--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -1,5 +1,12 @@
+#include "fileOperations.h"
 #include <nds.h>
 #include <stdio.h>
+#include <dirent.h>
+#include <vector>
+
+#include "file_browse.h"
+
+using namespace std;
 
 #define copyBufSize 0x8000
 
@@ -26,61 +33,91 @@ off_t getFileSize(const char *fileName)
 	return fsize;
 }
 
+void dirCopy(DirEntry* entry, int i, const char *destinationPath, const char *sourcePath) {
+	vector<DirEntry> dirContents;
+	dirContents.clear();
+	if (entry->isDirectory)	chdir((sourcePath + ("/" + entry->name)).c_str());
+	getDirectoryContents(dirContents);
+	if (((int)dirContents.size()) == 1)	mkdir((destinationPath + ("/" + entry->name)).c_str(), 0777);
+	if (((int)dirContents.size()) != 1)	fcopy((sourcePath + ("/" + entry->name)).c_str(), (destinationPath + ("/" + entry->name)).c_str());
+}
+
 int fcopy(const char *sourcePath, const char *destinationPath)
 {
-    FILE* sourceFile = fopen(sourcePath, "rb");
-    off_t fsize = 0;
-    if (sourceFile) {
-        fseek(sourceFile, 0, SEEK_END);
-        fsize = ftell(sourceFile);			// Get source file's size
-		fseek(sourceFile, 0, SEEK_SET);
+	DIR *isDir = opendir (sourcePath);
+	
+	if (isDir != NULL) {
+		chdir(sourcePath);
+		vector<DirEntry> dirContents;
+		getDirectoryContents(dirContents);
+		DirEntry* entry = &dirContents.at(1);
+		
+		mkdir(destinationPath, 0777);
+		for (int i = 1; i < ((int)dirContents.size()); i++) {
+			chdir(sourcePath);
+			entry = &dirContents.at(i);
+			dirCopy(entry, i, destinationPath, sourcePath);
+		}
+
+		chdir (destinationPath);
+		chdir ("..");
+		return 1;
 	} else {
-		fclose(sourceFile);
-		return -1;
-	}
+	    FILE* sourceFile = fopen(sourcePath, "rb");
+	    off_t fsize = 0;
+	    if (sourceFile) {
+	        fseek(sourceFile, 0, SEEK_END);
+	        fsize = ftell(sourceFile);			// Get source file's size
+			fseek(sourceFile, 0, SEEK_SET);
+		} else {
+			fclose(sourceFile);
+			return -1;
+		}
 
-    FILE* destinationFile = fopen(destinationPath, "wb");
-	//if (destinationFile) {
-		fseek(destinationFile, 0, SEEK_SET);
-	/*} else {
-		fclose(sourceFile);
-		fclose(destinationFile);
-		return -1;
-	}*/
-
-	off_t offset = 0;
-	int numr;
-	while (1)
-	{
-		scanKeys();
-		if (keysHeld() & KEY_B) {
-			// Cancel copying
+	    FILE* destinationFile = fopen(destinationPath, "wb");
+		//if (destinationFile) {
+			fseek(destinationFile, 0, SEEK_SET);
+		/*} else {
 			fclose(sourceFile);
 			fclose(destinationFile);
 			return -1;
-			break;
+		}*/
+
+		off_t offset = 0;
+		int numr;
+		while (1)
+		{
+			scanKeys();
+			if (keysHeld() & KEY_B) {
+				// Cancel copying
+				fclose(sourceFile);
+				fclose(destinationFile);
+				return -1;
+				break;
+			}
+			printf ("\x1b[16;0H");
+			printf ("Progress:\n");
+			printf ("%i/%i Bytes", (int)offset, (int)fsize);
+
+			// Copy file to destination path
+			numr = fread(copyBuf, 2, copyBufSize, sourceFile);
+			fwrite(copyBuf, 2, numr, destinationFile);
+			offset += copyBufSize;
+
+			if (offset > fsize) {
+				fclose(sourceFile);
+				fclose(destinationFile);
+
+				printf ("\x1b[17;0H");
+				printf ("%i/%i Bytes", (int)fsize, (int)fsize);
+				for (int i = 0; i < 60; i++) swiWaitForVBlank();
+
+				return 1;
+				break;
+			}
 		}
-		printf ("\x1b[16;0H");
-		printf ("Progress:\n");
-		printf ("%i/%i Bytes", (int)offset, (int)fsize);
 
-		// Copy file to destination path
-		numr = fread(copyBuf, 2, copyBufSize, sourceFile);
-		fwrite(copyBuf, 2, numr, destinationFile);
-		offset += copyBufSize;
-
-		if (offset > fsize) {
-			fclose(sourceFile);
-			fclose(destinationFile);
-
-			printf ("\x1b[17;0H");
-			printf ("%i/%i Bytes", (int)fsize, (int)fsize);
-			for (int i = 0; i < 60; i++) swiWaitForVBlank();
-
-			return 1;
-			break;
-		}
+		return -1;
 	}
-
-	return -1;
+	closedir(isDir);
 }

--- a/arm9/source/fileOperations.h
+++ b/arm9/source/fileOperations.h
@@ -1,3 +1,5 @@
+#include <nds.h>
+
 #ifndef FILE_COPY
 #define FILE_COPY
 

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -587,7 +587,7 @@ string browseForFile (void) {
 						getDirectoryContents (dirContents);
 					}
 				}
-			} else if ((strcmp(entry->name.c_str(), "..") != 0) {
+			} else if (strcmp(entry->name.c_str(), "..") != 0) {
 				snprintf(clipboard, sizeof(clipboard), "%s%s", path, entry->name.c_str());
 				snprintf(clipboardFilename, sizeof(clipboardFilename), "%s", entry->name.c_str());
 				clipboardOn = true;

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -49,13 +49,6 @@ using namespace std;
 
 static char path[PATH_MAX];
 
-struct DirEntry {
-	string name;
-	off_t size;
-	bool isDirectory;
-	bool isApp;
-} ;
-
 bool nameEndsWith (const string& name) {
 
 	if (name.size() == 0) return false;
@@ -594,7 +587,7 @@ string browseForFile (void) {
 						getDirectoryContents (dirContents);
 					}
 				}
-			} else if ((strcmp(entry->name.c_str(), "..") != 0) && !entry->isDirectory) {
+			} else if ((strcmp(entry->name.c_str(), "..") != 0) {
 				snprintf(clipboard, sizeof(clipboard), "%s%s", path, entry->name.c_str());
 				snprintf(clipboardFilename, sizeof(clipboardFilename), "%s", entry->name.c_str());
 				clipboardOn = true;

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -25,7 +25,17 @@
 #include <string>
 #include <vector>
 
+using namespace std;
+
+struct DirEntry {
+	string name;
+	off_t size;
+	bool isDirectory;
+	bool isApp;
+} ;
+
 std::string browseForFile (void);
+void getDirectoryContents (vector<DirEntry>& dirContents);
 
 
 


### PR DESCRIPTION
This fixes GM9i deleting your file when copying to the same dir, and adds recursive copying (copy files and dirs within dirs) (also undoes disabling copying folders because this fixes that)

***NOTE:*** **This has not been tested on the latest version as the `screenshot.h` and `bmp.h` files are *missing*, preventing me from building the app.**

This has been tested with a base of commit ea6d8e2cf21a43d5e515ae4b949d4b8f699b721a, and it looks like the code *should* work on the latest version, but I cannot test as `screenshot.h` and `bmp.h` are missing, so please test this before merging.

This [Stress.zip](https://github.com/RocketRobz/GodMode9i/files/2495066/Stress.zip) is the folder I was using to stress test the copying code, so feel free to test with this.

Or if you add the `screenshot.h` and `bmp.h` files, I can test it.
