### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
-<p align= "center">
-<img src="https://github.com/RocketRobz/GodMode9i/blob/master/resources/logo2_small.png">
-<h4 align= "center">A full access file browser for the DS and DSi consoles_ :godmode:</h4>
-<p align= "center">
- <span style="padding-right: 5px;">
-  <a href="https://travis-ci.org/RocketRobz/GodMode9i">
-   <img src="https://travis-ci.org/RocketRobz/GodMode9i.svg?branch=master">
-  </a>
-  </span>
-  <span style="padding-left: 5px;">
-  <a href="https://discord.gg/yqSut8c">
-   <img src="https://img.shields.io/badge/Discord-Server-blue.svg" height="20">
-  </a>
- </span>
+<p align="center">
+	<img src="https://github.com/RocketRobz/GodMode9i/blob/master/resources/logo2_small.png">
+	<h4 align="center">A full access file browser for the DS and DSi consoles :godmode:</h4>
 </p>
+
+<p align="center">
+	<a href="https://dev.azure.com/DS-Homebrew/Builds/_build?definitionId=14" style="padding-right: 5px;">
+   <img src="https://dev.azure.com/DS-Homebrew/Builds/_apis/build/status/RocketRobz.GodMode9i?branchName=master" height="20">
+  </a>
+	<a href="https://discord.gg/yqSut8c" style="padding-left: 5px;">
+		<img src="https://img.shields.io/badge/Discord-Server-blue.svg" height="20">
+	</a>
+</p>
+
+GodMode9i is a full access file browser for the Nintendo DS, Nintendo DSi and the Nintendo 3DS library of consoles. It works on any console that either supports a flashcard or has Custom Firmware.
 
 ## Features
 
-Dump GBA games on the original DS and DS Lite.
-
-Copy, move, delete, rename files/folders and create folders.
-
-Mount the NitroFS for .nds files, including retail ones.
-
-Works on any console that supports a flashcard, or has CFW! (includes original DS, DSi, and 3DS family of systems)
-
-View files on supported flashcards when running GM9i from the SD Card. (`AceKard 2(i)` `R4 Ultra (r4ultra.com)`)
+- Dump GameBoy Advance cartridges on the original Nintendo DS and Nintendo DS Lite consoles.
+- Copy, move, delete, rename files/folders and create folders.
+- Mount the NitroFS for .nds files, including retail ones
+- View files on supported flashcards when running GM9i from the SD Card. (`AceKard 2(i)` `R4 Ultra (r4ultra.com)`)
 
 ## Credits
-* d0k3: Original GM9 app and name, though he is not involved with the development of GM9i.
+* RocketRobz: Creator of GodMode9i.
+* zacchi4k: Creator of the GodMode9i logo used in v1.3.1 and onwards.
 * devkitPro/WinterMute: devkitARM, libnds, original nds-hb-menu code, and screenshot code.
-* THEGUY: GM9i logo used up to v1.3.0
-* zacchi4k: GM9i logo used in v1.3.1 and later
+* d0k3: Original GM9 app and name for the Nintendo 3DS, which this is based off of.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 <p align="center">
-	<img src="https://github.com/RocketRobz/GodMode9i/blob/master/resources/logo2_small.png">
-	<h4 align="center">A full access file browser for the DS and DSi consoles :godmode:</h4>
+	<img src="https://github.com/RocketRobz/GodMode9i/blob/master/resources/logo2_small.png"><br>
+	<b>A full access file browser for the DS and DSi consoles :godmode:</b>
 </p>
 
 <p align="center">
 	<a href="https://dev.azure.com/DS-Homebrew/Builds/_build?definitionId=14" style="padding-right: 5px;">
-   <img src="https://dev.azure.com/DS-Homebrew/Builds/_apis/build/status/RocketRobz.GodMode9i?branchName=master" height="20">
-  </a>
-	<a href="https://discord.gg/yqSut8c" style="padding-left: 5px;">
+		<img src="https://dev.azure.com/DS-Homebrew/Builds/_apis/build/status/RocketRobz.GodMode9i?branchName=master" height="20">
+	</a>
+	<a href="https://discord.gg/yqSut8c" style="padding-left: 5px; padding-right: 5px;">
 		<img src="https://img.shields.io/badge/Discord-Server-blue.svg" height="20">
+	</a>
+	<a href="https://gbatemp.net/threads/release-godmode9i-all-access-file-browser-for-the-ds-i-and-3ds.520096/" style="padding-left: 5px;">
+		<img src="https://img.shields.io/badge/GBATemp-thread-blue.svg" height="20">
 	</a>
 </p>
 
@@ -18,11 +21,26 @@ GodMode9i is a full access file browser for the Nintendo DS, Nintendo DSi and th
 
 - Dump GameBoy Advance cartridges on the original Nintendo DS and Nintendo DS Lite consoles.
 - Copy, move, delete, rename files/folders and create folders.
-- Mount the NitroFS for .nds files, including retail ones
+- Mount the NitroFS for .nds files (allowing you to browse through them), including retail nds files.
 - View files on supported flashcards when running GM9i from the SD Card. (`AceKard 2(i)` `R4 Ultra (r4ultra.com)`)
+
+## Building
+If you don't want to compile yourself but you still want to get the latest build, please use our [TWLBot github repository](https://github.com/TWLBot/Builds/blob/master/extras/GodMode9i.7z)
+
+In order to compile this application on your own, you will need [devkitPro](https://devkitpro.org/) with the devkitARM toolchain, plus the necessary tools and libraries. devkitPro includes `dkp-pacman` for easy installation of all components:
+
+```
+ $ dkp-pacman -Syu devkitARM general-tools dstools ndstool libnds libfat-nds
+```
+
+Once everything is downloaded and installed, `git clone` this repository, navigate to the folder in which it was cloned, and run `make` to compile the application. If there is an error, let us know.
+
+## Screenshots
+
+![](https://gbatemp.b-cdn.net/attachments/snap_212809-png.147117/)![](https://gbatemp.b-cdn.net/attachments/snap_211051-png.147114/)![](https://gbatemp.b-cdn.net/attachments/file-options-v1-3-0-no-border-png.147118/)
 
 ## Credits
 * RocketRobz: Creator of GodMode9i.
 * zacchi4k: Creator of the GodMode9i logo used in v1.3.1 and onwards.
 * devkitPro/WinterMute: devkitARM, libnds, original nds-hb-menu code, and screenshot code.
-* d0k3: Original GM9 app and name for the Nintendo 3DS, which this is based off of.
+* d0k3: Original GM9 app and name for the Nintendo 3DS, which this is inspired by.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,9 @@ steps:
      cp GodMode9i.7z $(Build.ArtifactStagingDirectory)/GodMode9i.7z
   displayName: 'Pack 7z'
 
-- script: |    
+- script: |
+    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull'))
+
     export COMMIT_TAG="$(git log --format=%h -1)"
     git config --global user.email "flamekat54@aol.com"
     git config --global user.name "TWLBot"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,6 @@ steps:
   displayName: 'Pack 7z'
 
 - script: |
-    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull'))
-
     export COMMIT_TAG="$(git log --format=%h -1)"
     git config --global user.email "flamekat54@aol.com"
     git config --global user.name "TWLBot"


### PR DESCRIPTION
- Organized credits
- Why isn't RocketRobz in the credits? He's the app creator
- Make features tab look good with the MarkDown parser Github uses
- Make the HTML valid. There was no closing to the paragraph tag, breaking a bunch of things.
- Change `GBA games` to `GBA cartridges`, since it's not just games that were on the Nintendo GameBoy Advanced
- Add a short description under the logo and the equivilent icons.
- Remove span stuff. There's no need when you can just embed the padding on the actionLink itself.

Flame, if you don't know HTML, don't try to do it