### PR TITLE
Fix file browsing being super flickery

### DIFF
--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -52,6 +52,8 @@ static int dmMaxCursors = -1;
 
 static u8 gbaFixedValue = 0;
 
+extern PrintConsole topConsole, bottomConsole;
+
 void dm_drawTopScreen(void) {
 	/*if (!ramDumped) {
 		printf ("Dumping RAM...");
@@ -61,8 +63,11 @@ void dm_drawTopScreen(void) {
 		consoleClear();
 		ramDumped = true;
 	}*/
+
+	consoleClear();
+
 	printf ("\x1B[42m");		// Print green color
-	printf ("________________________________");
+	printf ("___________________________%s", RetTime().c_str());
 	printf ("\x1b[0;0H");
 	printf ("[root]");
 	printf ("\x1B[47m");		// Print foreground white color
@@ -111,6 +116,8 @@ void dm_drawTopScreen(void) {
 }
 
 void dm_drawBottomScreen(void) {
+	consoleClear();
+
 	printf ("\x1B[47m");		// Print foreground white color
 	printf ("\x1b[23;0H");
 	printf (titleName);
@@ -208,9 +215,9 @@ void driveMenu (void) {
 		if (dmCursorPosition > dmMaxCursors)	dmCursorPosition = 0;		// Wrap around to top of list
 
 		if (!dmTextPrinted) {
-			consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+			consoleSelect(&bottomConsole);
 			dm_drawBottomScreen();
-			consoleInit(NULL, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, true, true);
+			consoleSelect(&topConsole);
 			dm_drawTopScreen();
 
 			dmTextPrinted = true;
@@ -328,9 +335,9 @@ void driveMenu (void) {
 				screenshotbmp(snapPath);
 				// Seamlessly swap top and bottom screens
 				lcdMainOnBottom();
-				consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, true, true);
+				consoleSelect(&bottomConsole);
 				dm_drawBottomScreen();
-				consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+				consoleSelect(&topConsole);
 				dm_drawTopScreen();
 				printf("\x1B[42m");		// Print green color for time text
 				printf("\x1b[0;27H");

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -11,6 +11,8 @@
 #include "read_card.h"
 #include "tonccpy.h"
 
+extern PrintConsole topConsole, bottomConsole;
+
 void ndsCardSaveDump(const char* filename) {
 	std::ofstream output(filename, std::ofstream::binary);
 	if(output.is_open()) {
@@ -49,7 +51,8 @@ void ndsCardDump(void) {
 	printf ("\x1b[0;27H");
 	printf ("\x1B[42m");		// Print green color
 	printf ("_____");	// Clear time
-	consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+	consoleSelect(&bottomConsole);
+	consoleClear();
 	printf ("\x1B[47m");		// Print foreground white color
 	printf("Dump NDS card ROM to\n");
 	printf("\"%s:/gm9i/out\"?\n", (sdMounted ? "sd" : "fat"));
@@ -173,7 +176,8 @@ void gbaCartDump(void) {
 	printf ("\x1b[0;27H");
 	printf ("\x1B[42m");		// Print green color
 	printf ("_____");	// Clear time
-	consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+	consoleSelect(&bottomConsole);
+	consoleClear();
 	printf ("\x1B[47m");		// Print foreground white color
 	printf("Dump GBA cart ROM to\n");
 	printf("\"fat:/gm9i/out\"?\n");

--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -23,20 +23,20 @@ bool clipboardInNitro = false;
 
 void printBytes(int bytes)
 {
-	if (abs(bytes) == 1)
-		iprintf("%d Byte", bytes);
+	if (bytes == 1)
+		iprintf("%4d Byte", bytes);
 
-	else if (abs(bytes) < 1024)
-		iprintf("%d Bytes", bytes);
+	else if (bytes < 1024)
+		iprintf("%3d Bytes", bytes);
 
-	else if (abs(bytes) < 1024 * 1024)
-		printf("%.1f KB", (float)bytes / 1024);
+	else if (bytes < 1024 * 1024)
+		printf("%6d KB", bytes / 1024);
 
-	else if (abs(bytes) < 1024 * 1024 * 1024)
-		printf("%.1f MB", (float)bytes / 1024 / 1024);
+	else if (bytes < 1024 * 1024 * 1024)
+		printf("%6d MB", bytes / 1024 / 1024);
 
 	else
-		printf("%.1f GB", (float)bytes / 1024 / 1024 / 1024);
+		printf("%6d GB", bytes / 1024 / 1024 / 1024);
 }
 
 off_t getFileSize(const char *fileName)

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -44,8 +44,7 @@
 #define OPTIONS_ENTRIES_START_ROW 2
 #define ENTRY_PAGE_LENGTH 10
 bool bigJump = false;
-
-using namespace std;
+extern PrintConsole topConsole, bottomConsole;
 
 static char path[PATH_MAX];
 
@@ -132,12 +131,11 @@ void getDirectoryContents (vector<DirEntry>& dirContents) {
 void showDirectoryContents (const vector<DirEntry>& dirContents, int fileOffset, int startRow) {
 	getcwd(path, PATH_MAX);
 	
-	// Clear the screen
-	iprintf ("\x1b[2J");
+	consoleClear();
 	
 	// Print the path
 	printf ("\x1B[42m");		// Print green color
-	printf ("________________________________");
+	printf ("___________________________%s", RetTime().c_str());
 	printf ("\x1b[0;0H");
 	if (strlen(path) < SCREEN_COLS) {
 		iprintf ("%s", path);
@@ -151,7 +149,6 @@ void showDirectoryContents (const vector<DirEntry>& dirContents, int fileOffset,
 	// Print directory listing
 	for (int i = 0; i < ((int)dirContents.size() - startRow) && i < ENTRIES_PER_SCREEN; i++) {
 		const DirEntry* entry = &dirContents.at(i + startRow);
-		char entryName[SCREEN_COLS + 1];
 
 		// Set row
 		iprintf ("\x1b[%d;0H", i + ENTRIES_START_ROW);
@@ -163,9 +160,7 @@ void showDirectoryContents (const vector<DirEntry>& dirContents, int fileOffset,
 			printf ("\x1B[40m");		// Print foreground black color
 		}
 
-		strncpy (entryName, entry->name.c_str(), SCREEN_COLS);
-		entryName[SCREEN_COLS] = '\0';
-		printf (entryName);
+		printf ("%.*s", SCREEN_COLS, entry->name.c_str());
 		if (strcmp(entry->name.c_str(), "..") == 0) {
 			printf ("\x1b[%d;28H", i + ENTRIES_START_ROW);
 			printf ("(..)");
@@ -191,7 +186,8 @@ int fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 	printf ("\x1b[0;27H");
 	printf ("\x1B[42m");		// Print green color
 	printf ("_____");	// Clear time
-	consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+	consoleSelect(&bottomConsole);
+	consoleClear();
 	printf ("\x1B[47m");		// Print foreground white color
 	char fullPath[256];
 	snprintf(fullPath, sizeof(fullPath), "%s%s", path, entry->name.c_str());
@@ -318,10 +314,12 @@ bool fileBrowse_paste(char destPath[256]) {
 	int optionOffset = 0;
 	int maxCursors = -1;
 
+	consoleClear();
+
 	printf ("\x1b[0;27H");
 	printf ("\x1B[42m");		// Print green color
 	printf ("_____");	// Clear time
-	consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+	consoleSelect(&bottomConsole);
 	printf ("\x1B[47m");		// Print foreground white color
 	printf(clipboardFolder ? "Paste folder here?" : "Paste file here?");
 	printf("\n\n");
@@ -395,37 +393,27 @@ void recRemove(DirEntry* entry, std::vector<DirEntry> dirContents) {
 }
 
 void fileBrowse_drawBottomScreen(DirEntry* entry, int fileOffset) {
+	consoleClear();
+
 	printf ("\x1B[47m");		// Print foreground white color
 	printf ("\x1b[22;0H");
-	printf (titleName);
-	printf ("\n");
-	printf ("X - DELETE/[+R] RENAME file");
-	printf ("\n");
-	printf (clipboardOn ? "Y - PASTE file" : "Y - COPY file");
-	printf ("/[+R] CREATE entry");
-	if (!clipboardOn) {
-		printf ("\n");
-	}
-	printf ("R+A - Directory options");
-	printf ("\n");
-	printf (SCREENSHOTTEXT);
-	printf ("\n");
-	printf (clipboardOn ? "SELECT - Clear Clipboard" : "SELECT - Restore Clipboard");
-	printf ("\n");
+	printf ("%s\n", titleName);
+	printf ("X - DELETE/[+R] RENAME file\n");
+	printf ("%s/[+R] CREATE entry%s", clipboardOn ? "Y - PASTE file" : "Y - COPY file", clipboardOn ? "" : "\n");
+	printf ("R+A - Directory options\n");
+	printf ("%s\n", SCREENSHOTTEXT);
+	printf ("%s\n", clipboardOn ? "SELECT - Clear Clipboard" : "SELECT - Restore Clipboard");
 	if (!isDSiMode() && isRegularDS) {
 		printf (POWERTEXT_DS);
 	} else if (is3DS) {
-		printf (POWERTEXT_3DS);
-		printf ("\n");
-		printf (HOMETEXT);
+		printf ("%s\n%s", POWERTEXT_3DS, HOMETEXT);
 	} else {
 		printf (POWERTEXT);
 	}
 
 	printf ("\x1B[40m");		// Print foreground black color
 	printf ("\x1b[0;0H");
-	printf (entry->name.c_str());
-	printf ("\n");
+	printf ("%s\n", entry->name.c_str());
 	if (strcmp(entry->name.c_str(), "..") != 0) {
 		if (entry->isDirectory) {
 			printf ("(dir)");
@@ -456,9 +444,9 @@ string browseForFile (void) {
 	while (true) {
 		DirEntry* entry = &dirContents.at(fileOffset);
 
-		consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+		consoleSelect(&bottomConsole);
 		fileBrowse_drawBottomScreen(entry, fileOffset);
-		consoleInit(NULL, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, true, true);
+		consoleSelect(&topConsole);
 		showDirectoryContents (dirContents, fileOffset, screenOffset);
 
 		stored_SCFG_MC = REG_SCFG_MC;
@@ -511,11 +499,9 @@ string browseForFile (void) {
 		// Scroll screen if needed
 		if (fileOffset < screenOffset) 	{
 			screenOffset = fileOffset;
-			showDirectoryContents (dirContents, fileOffset, screenOffset);
 		}
 		if (fileOffset > screenOffset + ENTRIES_PER_SCREEN - 1) {
 			screenOffset = fileOffset - ENTRIES_PER_SCREEN + 1;
-			showDirectoryContents (dirContents, fileOffset, screenOffset);
 		}
 
 		getcwd(path, PATH_MAX);
@@ -597,6 +583,8 @@ string browseForFile (void) {
 			keyboardHide();
 			consoleClear();
 
+			consoleInit(&bottomConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+
 			if (newName[0] != '\0') {
 				// Check for unsupported characters
 				for (int i = 0; i < (int)sizeof(newName); i++) {
@@ -624,7 +612,8 @@ string browseForFile (void) {
 			printf ("\x1b[0;27H");
 			printf ("\x1B[42m");		// Print green color
 			printf ("_____");	// Clear time
-			consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+			consoleSelect(&bottomConsole);
+			consoleClear();
 			printf ("\x1B[47m");		// Print foreground white color
 			iprintf("Delete \"%s\"?\n", entry->name.c_str());
 			printf ("(<A> yes, <B> no)");
@@ -673,6 +662,8 @@ string browseForFile (void) {
 			newName[strlen(newName)-1] = 0;
 			keyboardHide();
 			consoleClear();
+
+			consoleInit(&bottomConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
 
 			if (newName[0] != '\0') {
 				if (mkdir(newName, 0777) == 0) {
@@ -730,9 +721,9 @@ string browseForFile (void) {
 			screenshotbmp(snapPath);
 			// Seamlessly swap top and bottom screens
 			lcdMainOnBottom();
-			consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, true, true);
+			consoleSelect(&bottomConsole);
 			fileBrowse_drawBottomScreen(entry, fileOffset);
-			consoleInit(NULL, 1, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+			consoleSelect(&topConsole);
 			showDirectoryContents (dirContents, fileOffset, screenOffset);
 			printf("\x1B[42m");		// Print green color for time text
 			printf ("\x1b[0;26H");

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -50,6 +50,8 @@ bool applaunch = false;
 
 static int bg3;
 
+PrintConsole topConsole, bottomConsole;
+
 using namespace std;
 
 //---------------------------------------------------------------------------------
@@ -99,7 +101,7 @@ int main(int argc, char **argv) {
 	// Subscreen as a console
 	videoSetModeSub(MODE_0_2D);
 	vramSetBankH(VRAM_H_SUB_BG);
-	consoleInit(NULL, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
+	consoleInit(&bottomConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, false, true);
 
 	// Display GM9i logo
 	bg3 = bgInit(3, BgType_Bmp16, BgSize_B16_256x256, 1, 0);
@@ -156,6 +158,7 @@ int main(int argc, char **argv) {
 	// Top screen as a console
 	videoSetMode(MODE_0_2D);
 	vramSetBankG(VRAM_G_MAIN_BG);
+	consoleInit(&topConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 15, 0, true, true);
 
 	keysSetRepeat(25,5);
 


### PR DESCRIPTION
- This fixes file browsing being super flickery, mostly by switching from re-initing the console to switch to selecting between two, but also
- The main downside is that I also had to switch the file size to use int division instead of float division, I tried keeping it float but it was always too slow and the console would flicker once a lot of files were on screen
- I've tested fairly thoroughly, but it is possible something's printing wrong since some things need additional clears since switching consoles doesn't clear like initing does

Tested on DSi (K) with the latest Unlaunch