### PR TITLE
Ramdrive capabilities improvement

### DIFF
--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -264,10 +264,10 @@ void driveMenu (void) {
 			romTitle[1][0] = 0;
 			romSize[1] = 0;
 		}
-		if (((io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) || (isRegularDS && !flashcardMounted && romTitle[1][0] != 0))
+		if (((io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) || ramdriveMounted || (isRegularDS && !flashcardMounted && romTitle[1][0] != 0))
 		|| (isDSiMode() && !arm7SCFGLocked && !(REG_SCFG_MC & BIT(0)))) {
 			dmOperations.push_back(DriveMenuOperation::ndsCard);
-			if(romTitle[0][0] == 0 && ((io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) || !flashcardMounted) && !isRegularDS) {
+			if(romTitle[0][0] == 0 && ((io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) || !flashcardMounted || ramdriveMounted) && !isRegularDS) {
 				sNDSHeaderExt ndsHeader;
 				cardInit(&ndsHeader);
 				tonccpy(romTitle[0], ndsHeader.gameTitle, 12);
@@ -364,7 +364,7 @@ void driveMenu (void) {
 					screenMode = 1;
 					break;
 				}
-			} else if (dmOperations[dmCursorPosition] == DriveMenuOperation::ndsCard && (sdMounted || flashcardMounted || romTitle[1][0] != 0)) {
+			} else if (dmOperations[dmCursorPosition] == DriveMenuOperation::ndsCard && (sdMounted || flashcardMounted || ramdriveMounted || romTitle[1][0] != 0)) {
 				ndsCardDump();
 			} else if (dmOperations[dmCursorPosition] == DriveMenuOperation::ramDrive && ramdriveMounted) {
 				currentDrive = Drive::ramDrive;

--- a/arm9/source/driveOperations.h
+++ b/arm9/source/driveOperations.h
@@ -38,6 +38,7 @@ extern u64 fatSize;
 extern u64 imgSize;
 extern u32 ramdSize;
 
+extern const char* getDefaultDrivePath(void);
 extern const char* getDrivePath(void);
 extern Drive getDriveFromPath(const char *path);
 

--- a/arm9/source/ramd.h
+++ b/arm9/source/ramd.h
@@ -4,6 +4,7 @@
 #include <nds/ndstypes.h>
 #include <nds/disc_io.h>
 
+extern u32 baseSectors;
 extern u32 ramdSectors;
 extern u8* ramdLocMep;
 

--- a/arm9/source/titleManager.cpp
+++ b/arm9/source/titleManager.cpp
@@ -63,7 +63,7 @@ void dumpTitle(TitleInfo &title) {
 	snprintf(dumpName, sizeof(dumpName), "%s_%s_%02X", title.gameTitle, title.gameCode, title.romVersion);
 
 	char dumpToStr[256];
-	snprintf(dumpToStr, sizeof(dumpToStr), STR_DUMP_TO.c_str(), dumpName, sdMounted ? "sd" : "fat");
+	snprintf(dumpToStr, sizeof(dumpToStr), STR_DUMP_TO.c_str(), dumpName, getDefaultDrivePath());
 
 	int y = font->calcHeight(dumpToStr) + 1;
 
@@ -131,14 +131,14 @@ void dumpTitle(TitleInfo &title) {
 
 			// Ensure directories exist
 			char folderPath[16];
-			sprintf(folderPath, "%s:/gm9i", (sdMounted ? "sd" : "fat"));
+			sprintf(folderPath, "%s:/gm9i", getDefaultDrivePath());
 			if (access(folderPath, F_OK) != 0) {
 				font->clear(false);
 				font->print(firstCol, 0, false, STR_CREATING_DIRECTORY, alignStart);
 				font->update(false);
 				mkdir(folderPath, 0777);
 			}
-			sprintf(folderPath, "%s:/gm9i/out", (sdMounted ? "sd" : "fat"));
+			sprintf(folderPath, "%s:/gm9i/out", getDefaultDrivePath());
 			if (access(folderPath, F_OK) != 0) {
 				font->clear(false);
 				font->print(firstCol, 0, false, STR_CREATING_DIRECTORY, alignStart);
@@ -150,31 +150,31 @@ void dumpTitle(TitleInfo &title) {
 			char inpath[64], outpath[64];
 			if((selectedOption & TitleDumpOption::rom) && (allowedBitfield & TitleDumpOption::rom)) {
 				snprintf(inpath, sizeof(inpath), "%s/content/%02x%02x%02x%02x.app", title.path.c_str(), title.appVersion[0], title.appVersion[1], title.appVersion[2], title.appVersion[3]);
-				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.nds", sdMounted ? "sd" : "fat", dumpName);
+				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.nds", getDefaultDrivePath(), dumpName);
 				fcopy(inpath, outpath);
 			}
 
 			if((selectedOption & TitleDumpOption::publicSave) && (allowedBitfield & TitleDumpOption::publicSave)) {
 				snprintf(inpath, sizeof(inpath), "%s/data/public.sav", title.path.c_str());
-				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.pub", sdMounted ? "sd" : "fat", dumpName);
+				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.pub", getDefaultDrivePath(), dumpName);
 				fcopy(inpath, outpath);
 			}
 
 			if((selectedOption & TitleDumpOption::privateSave) && (allowedBitfield & TitleDumpOption::privateSave)) {
 				snprintf(inpath, sizeof(inpath), "%s/data/private.sav", title.path.c_str());
-				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.prv", sdMounted ? "sd" : "fat", dumpName);
+				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.prv", getDefaultDrivePath(), dumpName);
 				fcopy(inpath, outpath);
 			}
 
 			if((selectedOption & TitleDumpOption::bannerSave) && (allowedBitfield & TitleDumpOption::bannerSave)) {
 				snprintf(inpath, sizeof(inpath), "%s/data/banner.sav", title.path.c_str());
-				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.bnr", sdMounted ? "sd" : "fat", dumpName);
+				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.bnr", getDefaultDrivePath(), dumpName);
 				fcopy(inpath, outpath);
 			}
 
 			if((selectedOption & TitleDumpOption::tmd) && (allowedBitfield & TitleDumpOption::tmd)) {
 				snprintf(inpath, sizeof(inpath), "%s/content/title.tmd", title.path.c_str());
-				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.tmd", sdMounted ? "sd" : "fat", dumpName);
+				snprintf(outpath, sizeof(outpath), "%s:/gm9i/out/%s.tmd", getDefaultDrivePath(), dumpName);
 				fcopy(inpath, outpath);
 			}
 


### PR DESCRIPTION
This PR will focus on making gm9i better use the ramdrive it currently has. The main motivation is being able to use most of the features of gm9i in an envirionment where no storage is available (for example when used throught download and play on an DS).
For the moment what was changed is:
 * Always creating a ramdrive even in DS mode, it will use approximately 1MB of ram, so that it will be able to hold most of the saves
 * As long as a ramdrive is present, even if no other storage is mounted, the cart dump operations will still be doable and will instead write to the ramdrive.
 * The ramdrive DLDI driver was updated slightly to remove repeated code.

There are still various other things that have to be updated:
 * The ramdrive would be usable as dump target only when nothing else is available, while it could be useful to be able to directly dump carts there (for some reason), so a way to prompt the user what drive to use as destination would be needed. (This scenario is actually already an issue when both slot-1 and the microsd are available.)
 * With the current changes, storing saves to gba carts is broken, as the ramdrive will always be used.
 * Could be useful to compress the saves like it's done when writing to gba carts to save space in the ramdrive.
 * In ds mode, if a slot2 memory expansion cart is inserted and then removed, the ramdrive will be unmounted and no longer available.
 * In general, in the dump operations, when selecting an option, it should be checked if enough space is available on that storage.