### PR TITLE
fix: Skip first-run language prompt if storage is read-only

### DIFF
--- a/arm9/source/config.cpp
+++ b/arm9/source/config.cpp
@@ -37,7 +37,8 @@ Config::Config() {
 
 	std::string langPath = ini.GetString("GODMODE9I", "LANGUAGE_INI_PATH", "DEFAULT_NOT_FOUND");
 	if (langPath == "DEFAULT_NOT_FOUND") {
-		_languagePromptNeeded = true;
+		bool isWritable = sdMounted ? driveWritable(Drive::sdCard) : (flashcardMounted && driveWritable(Drive::flashcard));
+		_languagePromptNeeded = isWritable;
 		char defaultLanguagePath[40];
 		sniprintf(defaultLanguagePath, sizeof(defaultLanguagePath), "nitro:/languages/%s/language.ini", getSystemLanguage());
 		_languageIniPath = defaultLanguagePath;


### PR DESCRIPTION
## Summary

On first boot (no config file), we check if the storage drive we intend to write our configuration file to is actually writable before showing the language prompt. If the medium is read-only or no SD/flashcard is present, the prompt is skipped and the auto-detected system language is used instead.

This fixes feedback on #262 where users on read-only systems or without an SD card inserted would be stuck in an infinite boot prompt loop.
